### PR TITLE
Fixes #5: Checking for application focus before tokenizing editor

### DIFF
--- a/lib/editor-tokens.js
+++ b/lib/editor-tokens.js
@@ -53,19 +53,23 @@ class EditorTokens {
       return;
     }
 
-    this.awaitingTokens = true;
-
     const grammar = atom.grammars.grammarForScopeName('source.java');
     if (!grammar) {
       // Not loaded. Java grammar possibly not installed. Skip refreshing.
       return;
     }
+    const focusedWindow = remote.BrowserWindow.getFocusedWindow();
+    if (!focusedWindow) {
+      // Lost focus. Skip refreshing.
+      return;
+    }
 
+    this.awaitingTokens = true;
     this.worker.webContents.send('grammar-path', grammar.path);
     this.worker.webContents.send('tokenize',
       editor.id,
       editor.getText(),
-      remote.BrowserWindow.getFocusedWindow().id
+      focusedWindow.id
     );
   }
 


### PR DESCRIPTION
This should address issue #5. There is a 300ms delay before `onDidStopChanging` is called. In this time it is possible for the application to lose focus. This causes the package to throw an `Uncaught TypeError`. Worse it puts the package into a state where `awaitingTokens` get's stuck at `true` and the editor will not be tokenized until restart.
